### PR TITLE
Add expiry time in TradeProposeReply

### DIFF
--- a/04-trade-protocol.md
+++ b/04-trade-protocol.md
@@ -113,6 +113,7 @@ message TradeProposeRequest {
 message TradeProposeReply {
   SwapAccept swap_accept = 1;
   SwapFail swap_fail = 2;
+  int64 expiry_time_unix = 3;
 }
 
 message TradeCompleteRequest {

--- a/04-trade-protocol.md
+++ b/04-trade-protocol.md
@@ -113,7 +113,7 @@ message TradeProposeRequest {
 message TradeProposeReply {
   SwapAccept swap_accept = 1;
   SwapFail swap_fail = 2;
-  int64 expiry_time_unix = 3;
+  uint64 expiry_time_unix = 3;
 }
 
 message TradeCompleteRequest {


### PR DESCRIPTION
Before this commit, there was no clear way to communicate to traders that their trade proposal would have been expired if not "closed" ASAP (to not have the UTXO on the Provider be locked indefinitely) 

Thanks to @FrancisPouliot for the suggestion.