### PR TITLE
Change from peer to handshake

### DIFF
--- a/00-index.md
+++ b/00-index.md
@@ -8,7 +8,7 @@ describe a protocol that provides an open interface for seamless exchange of [El
 
 * [BOTD #0: Index](00-index.md)
 * [BOTD #1: Message Protocol](01-message-protocol.md)
-* [BOTD #2: Peer Protocol](02-peer-protocol.md)
+* [BOTD #2: Handshake Protocol](02-handshake-protocol.md)
 * [BOTD #3: Swap Protocol](03-swap-protocol.md)
 * [BOTD #4: Trade Protocol](04-trade-protocol.md)
 

--- a/02-handshake-protocol.md
+++ b/02-handshake-protocol.md
@@ -1,4 +1,4 @@
-# BOTD #2: Peer Protocol
+# BOTD #2: Handshake Protocol
 
 
 ## Overview 
@@ -6,10 +6,6 @@
 All communications between two parties are encrypted in order to provide confidentiality for all transcripts and is authenticated in order to avoid malicious interference. Each node has a known long-term identifier that is a public key on Bitcoin's secp256k1 curve. This long-term public key is used within the protocol to establish an encrypted and authenticated connection with peers, and also to authenticate any information advertised on behalf of a node.
 
 An initial handshake is required to establish a secure TCP-based session between two nodes. The default listening TCP port is **9945** 
-
-
-
-## Handshake
 
 Prior to undertaking the handshake it is assumed that we have already established a dedicated bidirectional channel between both parties. Both peers generate an ephemeral keypair using the secp256 elliptic curve algorithm.
 

--- a/04-trade-protocol.md
+++ b/04-trade-protocol.md
@@ -13,7 +13,7 @@ The **market makers** provide always-on endpoints and put liquidity in various a
 
 Anyone can become a **liquidity provider** and contribute with reserves in a non-custodial manner running an always-on endpoint to process trading requests. This is different than buying or selling; it requires depositing an equivalent value of both base and quote assets and select an automated market making strategy. 
 
-A **trader** connects to the provider using the [secure transport defined in the BOTD #2](02-peer-protocol.md), fetches the current *market price* defined by the provider's strategy and makes an atomic swap using the [swap protocol defined in the BOTD #3](03-swap-protocol.md). Limit orders could be supported as well, delaying the time of execution of the swap proposal in the future.
+A **trader** connects to the provider using the [secure transport defined in the BOTD #2](02-handshake-protocol.md), fetches the current *market price* defined by the provider's strategy and makes an atomic swap using the [swap protocol defined in the BOTD #3](03-swap-protocol.md). Limit orders could be supported as well, delaying the time of execution of the swap proposal in the future.
 
 ## Glossary 
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,7 +2,7 @@
 
 * [BOTD #0: Index](00-index.md)
 * [BOTD #1: Message Protocol](01-message-protocol.md)
-* [BOTD #2: Peer Protocol](02-peer-protocol.md)
+* [BOTD #2: Handshake Protocol](02-handshake-protocol.md)
 * [BOTD #3: Swap Protocol](03-swap-protocol.md)
 * [BOTD #4: Trade Protocol](04-trade-protocol.md)
 


### PR DESCRIPTION
This commit changes the reference in the specification from peer to handshake protocol, since there is no ongoing peer to peer messaging going on after securing the transport