### PR TITLE
Use int64 instead of float for Fee field in custom types

### DIFF
--- a/04-trade-protocol.md
+++ b/04-trade-protocol.md
@@ -57,36 +57,6 @@ service Trade {
 }
 ```
 
-* Custom Types 
-
-```protobuf
-message Market {
-  string base_asset = 1;
-  string quote_asset = 2;
-}
-message MarketWithFee {
-  Market market = 1;
-  float fee = 2;
-}
-message Balance {
-  int64 base_amount = 1;
-  int64 quote_amount = 2;
-}
-message BalanceWithFee {
-  Balance balance = 1;
-  float fee = 2;
-}
-message Price {
-  float base_price = 1;
-  float quote_price = 2;
-}
-message PriceWithFee {
-  Price price = 1;
-  float fee = 2;
-}
-
-```
-
 * Messages 
 
 ```protobuf
@@ -125,6 +95,31 @@ message TradeCompleteReply { string txid = 1; }
 
 ```
 
+* Custom Types 
 
-
-
+```protobuf
+message Balance {
+  int64 base_amount = 1;
+  int64 quote_amount = 2;
+}
+message BalanceWithFee {
+  Balance balance = 1;
+  int64 fee = 2;
+}
+message Market {
+  string base_asset = 1;
+  string quote_asset = 2;
+}
+message MarketWithFee {
+  Market market = 1;
+  int64 fee = 2;
+}
+message Price {
+  float base_price = 1;
+  float quote_price = 2;
+}
+message PriceWithFee {
+  Price price = 1;
+  int64 fee = 2;
+}
+```


### PR DESCRIPTION
Before this commit, we had the fee in custom types expressed as a float. This could lead to errors in floating-point precisions in various languages. Therefore we use in64 and the fee MUST be intended as basis points.

Examples:

- A fee of 0.25% on each swap, should be written as 25
- A fee of 5% on each swap, should be written as 250

 The minimum MUST be 1 (0.01%) and the maximum 9900-9999 (~0.99%)

