### PR TITLE
Add SwapFail to TradeCompleteReply

### DIFF
--- a/04-trade-protocol.md
+++ b/04-trade-protocol.md
@@ -74,7 +74,10 @@ message TradeCompleteRequest {
   SwapComplete swap_complete = 1;
   SwapFail swap_fail = 2;
 }
-message TradeCompleteReply { string txid = 1; }
+message TradeCompleteReply {
+  string txid = 1;
+  SwapFail swap_fail = 2;
+}
 ```
 
 * Custom Types 


### PR DESCRIPTION
TradeComplete, like TradePropose, could fail to complete and broadcast the swap transaction, hence this adds an optional field `SwapFail swap_fail` to the reply

It closes #19 