### PR TITLE
BOTD #2: Announce supported content types & BOTD #4: Add grpc gateway notations

### DIFF
--- a/01-message-protocol.md
+++ b/01-message-protocol.md
@@ -6,6 +6,6 @@ A **connection** is a reliable, bidirectional communication channel between two 
 
 **Security** in this context means that all confidential communications SHOULD be encrypted, and that the identity of each peer SHOULD be cryptographically verifiable by the other peer.
 
-The messages exchanged between peers are serialized using [**Protocol Buffers**](https://developers.google.com/protocol-buffers/), a language-neutral, platform-neutral, extensible mechanism for serializing structured data.
+The messages exchanged between peers can be serialized using either [**Protocol Buffers**](https://developers.google.com/protocol-buffers/), a language-neutral, platform-neutral, extensible mechanism for serializing structured data, or `JSON utf8`.
 
  

--- a/02-transport-protocol.md
+++ b/02-transport-protocol.md
@@ -3,52 +3,57 @@
 
 ## Overview
 
-All communications between two *peers* SHOULD be encrypted in order to provide confidentiality for all transcripts and is authenticated in order to avoid malicious interference. 
+All communications between two *peers* SHOULD be encrypted in order to provide confidentiality for all transcripts and authenticated in order to avoid malicious interference.
 
+Following are examples of transport protocols for encrypted connection:
 
-
-### Transport announcement
-
-Each *peer* MUST decide and MUST announce which transport protocol wants to use for the connection, one or more combined between:
-
-
-* Clear text `insecure`
+* Clear text `insecure` (no encryption)
 * Onion service `onion`
 * Server-side TLS `TLS`
 * Mutual TLS `mTLS`
 * Noise_XK_secp256k1_ChaChaPoly_SHA256 `noise`
 
+The type of transport used by a peer can be easily determined by the canonical URL it can be reached at (ie. http -> insecure, https -> TLS/mTLS, .onion -> onion).
 
-Each peer SHOULD be reachable on the default TCP port **9945** and, if so, MUST expose then a plaintext HTTP/2 endpoint that announces the chosen transports responding with an `AvailableTransport` protobuf message, setting the response `ContentType` as `application/protobuf`
+### Message type announcement
+
+Liquidity providers MUST decide and announce the accepted content type for incoming HTTP request messages.
+
+Peers connecting to liquidity providers should ask for the accepted content types and use one of them to prevent using a non supported one.
+
+A liquidity provider can accept requests of different content types but **MUST** support at least `application/json`.
 
 
 #### Data Structures
 
-```protobuf
-syntax = "proto3";
+* Service interface
+	```protobuf
+	syntax = "proto3";
+	import "google/api/annotations.proto";
 
-enum TransportType {
-	INSECURE = 0;
-	ONION = 1;
-	TLS = 2;
-	MTLS = 3;
-	NOISE = 4;
-}
+	service Transport {
+		rpc SupportedContentTypes(SupportedContentTypesRequest) returns (SupportedContentTypesReply) {
+			option (google.api.http) = {
+				get: "/v1/supported_types"
+			};
+		}
+	}
+	```
 
-message Transport {
-	TransportType type = 1;
-	string name = 2;
-	bytes data = 3;
-}
+* Messages
+  ```protobuf
+	enum ContentType {
+		JSON = 0;
+		GRPC = 1;
+		GRPCWEB = 2;
+		GRPCWEBTEXT = 3;
+	}
 
-message AvailableTransport {
-	repeated TransportType transport = 1;
-}
-
-```
-
-Each `Transport` has an optional `data` field that can be used to return additional metadata. Eg. A static public key in case of `noise` or a self-signed TLS certificate in case of `mTLS`
-
+	message SupportedContentTypesRequest {}
+	message SupportedContentTypesReply {
+		repeated ContentType accepted_types = 1;
+	}
+	```
 
 
 

--- a/02-transport-protocol.md
+++ b/02-transport-protocol.md
@@ -5,14 +5,6 @@
 
 All communications between two *peers* SHOULD be encrypted in order to provide confidentiality for all transcripts and authenticated in order to avoid malicious interference.
 
-Following are examples of transport protocols for encrypted connection:
-
-* Clear text `insecure` (no encryption)
-* Onion service `onion`
-* Server-side TLS `TLS`
-* Mutual TLS `mTLS`
-* Noise_XK_secp256k1_ChaChaPoly_SHA256 `noise`
-
 The type of transport used by a peer can be easily determined by the canonical URL it can be reached at (ie. http -> insecure, https -> TLS/mTLS, .onion -> onion).
 
 ### Message type announcement

--- a/04-trade-protocol.md
+++ b/04-trade-protocol.md
@@ -34,14 +34,40 @@ A **trader** connects to the provider using the [secure transport defined in the
 * Service Interface
 
 ```protobuf
+syntax = "proto3";
+import "google/api/annotations.proto";
+
 service Trade {
-  rpc Markets(MarketsRequest) returns (MarketsReply);
-  rpc Balances(BalancesRequest) returns (BalancesReply);
-  rpc MarketPrice(MarketPriceRequest) returns (MarketPriceReply);
+  rpc Markets(MarketsRequest) returns (MarketsReply) {
+    option (google.api.http) = {
+      get: "/v1/markets"
+    };
+  }
+  rpc Balances(BalancesRequest) returns (BalancesReply) {
+    option (google.api.http) = {
+      get: "/v1/market/{base_asset}/{quote_asset}/balance"
+    };
+  }
+  rpc MarketPrice(MarketPriceRequest) returns (MarketPriceReply) {
+    option (google.api.http) = {
+      post: "/v1/market/price"
+      body: "*"
+    };
+  }
   rpc TradePropose(TradeProposeRequest) returns (stream TradeProposeReply);
   rpc TradeComplete(TradeCompleteRequest) returns (stream TradeCompleteReply);
-  rpc ProposeTrade(ProposeTradeRequest) returns (ProposeTradeReply);
-  rpc CompleteTrade(CompleteTradeRequest) returns (CompleteTradeReply);
+  rpc ProposeTrade(ProposeTradeRequest) returns (ProposeTradeReply) {
+    option (google.api.http) = {
+      post: "/v1/trade/propose"
+      body: "*"
+    };
+  }
+  rpc CompleteTrade(CompleteTradeRequest) returns (CompleteTradeReply) {
+    option (google.api.http) = {
+      post: "/v1/trade/complete"
+      body: "*"
+    };
+  }
 }
 ```
 

--- a/04-trade-protocol.md
+++ b/04-trade-protocol.md
@@ -45,7 +45,8 @@ service Trade {
   }
   rpc Balances(BalancesRequest) returns (BalancesReply) {
     option (google.api.http) = {
-      get: "/v1/market/{base_asset}/{quote_asset}/balance"
+      post: "/v1/market/balance"
+      body: "*"
     };
   }
   rpc MarketPrice(MarketPriceRequest) returns (MarketPriceReply) {


### PR DESCRIPTION
This updates the BOTD #2 adding the definition of the Transport service for announcing supported content types.

Also, this adds grpc gateway notation to the methods of the service defined in BOTD #4

Closes #38.

Please @tiero review this.